### PR TITLE
fix: PropertySource utf-8 인코딩 추가

### DIFF
--- a/src/main/java/annotation/PropertyConfig.java
+++ b/src/main/java/annotation/PropertyConfig.java
@@ -7,6 +7,6 @@ import org.springframework.context.annotation.PropertySource;
 
 @Configuration
 @ComponentScan(basePackageClasses = SampleValue.class)
-@PropertySource("classpath:application.properties")
+@PropertySource(value = "classpath:application.properties", encoding = "UTF-8")
 public class PropertyConfig {
 }


### PR DESCRIPTION
안녕하세요 구구!

다름이 아니라 테스트를 해보고 있는데 `AnnotationBasedConfiguration` 클래스의 `@Value 사용하기` 테스트가 통과가 안 되더라구요.

![image](https://github.com/kang-hyungu/di-study/assets/116627736/482b2ca1-bf86-478e-ad55-9cccb4578f18)

원인을 파악해보니 `application.properties` 파일의 인코딩이 UTF-8로 되어있어서 발생하는 문제 같아 PR 남깁니다!

![image](https://github.com/kang-hyungu/di-study/assets/116627736/180273df-0337-4f40-b676-cb0cd123ed37)

---

그리고 이건 의견인데 `@Qualifier로 주입 받을 Bean 지정하기` 테스트에 검증을 다음과 같이 하더라구요!

```kotlin
movieCatalog.shouldBeTypeOf<Object>()
```

그런데 해당 테스트의 문맥상 타입으로 검사하는 것이 아닌, 주입 받은 빈이 어떠한 이름으로 주입되었는지 판단하는 것 같아 다음과 같은 검증이 더 명확할 것 같습니다..!

```kotlin
movieCatalog shouldBe applicationContext.getBean("")
```